### PR TITLE
Created executor to work with Arduino serial

### DIFF
--- a/prototype/ros/.gitignore
+++ b/prototype/ros/.gitignore
@@ -1,0 +1,3 @@
+build
+log
+install

--- a/prototype/ros/motor_controls_ws/src/motors/motors/serial_executor.py
+++ b/prototype/ros/motor_controls_ws/src/motors/motors/serial_executor.py
@@ -1,0 +1,83 @@
+import rclpy
+
+from rclpy.node import Node
+from rclpy.executors import SingleThreadedExecutor
+from std_msgs.msg import String
+
+import serial
+
+arduino = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=.5)
+
+executor_timeout = 0.1
+
+class ArduinoWriter(Node):
+    """
+    Listens to the '/write_arduino_message' topic and writes those messages to the Arduino via serial connection
+    """
+    def __init__(self):
+        super().__init__("ArduinoWriterNode")
+        self._subscription = self.create_subscription(String, "/write_arduino_message", self.writeTopicMessageToArduino, 100)
+
+
+    def writeTopicMessageToArduino(self, message):
+        """
+        Writes the message to the Arduino via serial connection
+        """
+        command = message.data
+
+        arduino.write(bytes(command, 'ascii'))
+
+
+class ArduinoMessageDistributor(Node):
+    """
+    Reads Arduino serial messages and distributes them to the correct topics
+    """
+    def __init__(self):
+        super().__init__("ArduinoMessageDistributorNode")
+        self._publisher = self.create_publisher(String, "/publish_arduino_message", 100)
+
+        self.timer_period = 0.1
+        self.timer = self.create_timer(self.timer_period, self.distributeArduinoMessage)
+
+    
+    def distributeArduinoMessage(self):
+        """
+        Reads a single message and publishes it to the correct topic
+        """
+        if(arduino.in_waiting > 0):
+            arduino_data = arduino.readline().decode()
+
+            message_to_publish = String()
+            message_to_publish.data = arduino_data
+
+            self._publisher.publish(message_to_publish)
+    
+    
+
+
+def main(args=None):
+
+    rclpy.init()
+
+    arduino_writer_node = ArduinoWriter()
+    arduino_distributor_node = ArduinoMessageDistributor()
+
+    executor = SingleThreadedExecutor()
+    executor.add_node(arduino_writer_node)
+    executor.add_node(arduino_distributor_node)
+
+    try:
+        while rclpy.ok():
+            executor.spin_once(timeout_sec=executor_timeout)
+    finally:
+        arduino_writer_node.destroy_node()
+        arduino_distributor_node.destroy_node()
+
+        rclpy.shutdown()
+        return
+
+
+
+if __name__ == '__main__':
+
+   main()

--- a/prototype/ros/motor_controls_ws/src/motors/setup.py
+++ b/prototype/ros/motor_controls_ws/src/motors/setup.py
@@ -20,6 +20,7 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'serial_executor=motors.serial_executor:main'
         ],
     },
 )


### PR DESCRIPTION
Closes #3 

### General Notes
Currently all Arduino messages get published to the same topic. More topics are to be added when needed for specific messages (ToF sensor values, encoders...). The frequency for the read timer as well as the timeout of the executor spin_once() method have been chosen arbitrarily. If anything fails, they should be changed first.

### Testing
Easiest way to test this functionality is to run the node `ros2 run motors serial_executor`. Then, in two separate terminals, run 
```bash
ros2 topic echo /publish_arduino_message

ros2 topic pub /write_arduino_message std_msgs/msg/String 'data: "<MESSAGE>"'
```
In the last command, replace <MESSAGE> with your message. 

The Arduino should have the sketch_dec6a.ino sketch. Then, publishing "YES" to /write_arduino_message will result in output "WE GOOD", publishing "NO" will result in "WE BAD", and any other string will result in the Arduino outputting "WE NEUTRAL"